### PR TITLE
Add test step to the push workflow too

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,6 +1,7 @@
 on:
   pull_request:
     paths:
+      - .github/workflows/pr.yml
       - src/**/*
       - test/**/*
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,11 @@ jobs:
         with:
           node-version: "16.x"
 
+      - name: Restore deps and test
+        run: |
+          npm ci
+          npm test
+
       - uses: sterlingwes/gh-pages-deploy-action@v1.1
         with:
           access-token: ${{ secrets.GH_PAT }}

--- a/test/app.spec.ts
+++ b/test/app.spec.ts
@@ -16,7 +16,7 @@ test("download buttons are enabled", async ({ page }) => {
         await expect(btn).toBeEnabled();
         const link = await btn.getAttribute("href");
         expect(link).toMatch(
-            /(https:\/\/github\.com\/pulumi-desktop\/app\/releases\/download\/)(v[0-9]+\.[0-9]+\.[0-9]+\/)(.*)(\.snap|dmg|exe)/g
+            /(https:\/\/github\.com\/deskypus\/app\/releases\/download\/)(v[0-9]+\.[0-9]+\.[0-9]+\/)(.*)(\.snap|dmg|exe)/g
         );
     }
 });


### PR DESCRIPTION
⚠️ the PR workflow will fail until a public release of the app is made available in the `app` repo. It is also why this should not be force-merged until then since the CI workflow would fail too because of the test.