### PR TITLE
Switch to tar.gz downloads for Linux

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -20,16 +20,27 @@
                 to Pulumi or a seasoned user, Deskypus aims to simplify your development workflow.
             </p>
             <div class="grid">
-                <a
-                    role="button"
-                    href="#"
-                    class="download-btn version-tooltip-target"
-                    disabled
-                    data-os="linux"
-                    data-test="linux_x64"
-                >
-                    Download for Linux
-                </a>
+                <details role="list" style="margin-bottom: 0" class="linux version-tooltip-target">
+                    <summary aria-haspopup="listbox" role="button">Download for Linux</summary>
+                    <ul role="listbox" style="padding-left: 0">
+                        <li>
+                            <a href="https://snapcraft.io/deskypus" target="_blank" rel="noopener">
+                                Install from Snapcraft Store
+                            </a>
+                        </li>
+                        <li>
+                            <a
+                                href="#"
+                                class="download-btn"
+                                disabled
+                                data-os="linux"
+                                data-test="linux_x64"
+                            >
+                                Download .tar.gz file
+                            </a>
+                        </li>
+                    </ul>
+                </details>
                 <details role="list" style="margin-bottom: 0" class="darwin version-tooltip-target">
                     <summary aria-haspopup="listbox" role="button">Download for macOS</summary>
                     <ul role="listbox" style="padding-left: 0">

--- a/src/main.ts
+++ b/src/main.ts
@@ -46,20 +46,20 @@ function enableDownloadButtons() {
         let releaseAsset: ReleaseAsset | undefined;
         switch (os) {
             case "linux":
-                releaseAsset = latestRelease.assets.find((a) => a.name.includes("snap"));
+                releaseAsset = latestRelease.assets.find((a) => a.name.endsWith("tar.gz"));
                 break;
             case "darwin":
                 if (arch) {
-                    releaseAsset = latestRelease.assets.find((a) => a.name.includes(arch) && a.name.includes("dmg"));
+                    releaseAsset = latestRelease.assets.find((a) => a.name.includes(arch) && a.name.endsWith("dmg"));
                 } else {
                     // TODO: Temporary hack until all release assets have the architecture in their names.
                     releaseAsset = latestRelease.assets.find(
-                        (a) => !a.name.includes("arm64") && a.name.includes("dmg")
+                        (a) => !a.name.includes("arm64") && a.name.endsWith("dmg")
                     );
                 }
                 break;
             case "windows":
-                releaseAsset = latestRelease.assets.find((a) => a.name.includes("exe"));
+                releaseAsset = latestRelease.assets.find((a) => a.name.endsWith("exe"));
                 break;
             default:
                 throw new Error(`Unknown OS type ${os}`);

--- a/test/app.spec.ts
+++ b/test/app.spec.ts
@@ -15,7 +15,7 @@ test("download buttons are enabled", async ({ page }) => {
         await expect(btn).toBeEnabled();
         const link = await btn.getAttribute("href");
         expect(link).toMatch(
-            /(https:\/\/github\.com\/deskypus\/app\/releases\/download\/)(v[0-9]+\.[0-9]+\.[0-9]+\/)(.*)(-arm64)?(\.snap|dmg|exe)/g
+            /(https:\/\/github\.com\/deskypus\/app\/releases\/download\/)(v[0-9]+\.[0-9]+\.[0-9]+\/)(.*)(-arm64)?(\.snap|.tar.gz|dmg|exe)/g
         );
     }
 });


### PR DESCRIPTION
From `v0.0.57` onwards, releases will have a `.tar.gz` release asset available.